### PR TITLE
Added GetLength and ConvertTagList using the codesets library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOTPATH:=$(abspath ../../../)
+ROOTPATH:=$(abspath ../../sdk/)
 LIB:=$(ROOTPATH)/lib
 GEN:=$(ROOTPATH)/gen/host/libnix
 
@@ -14,6 +14,13 @@ OBJC:=$(ROOTPATH)/morphoswb/classes/frameworks/includes/
 
 CMAKE = cmake
 STRIP = ppc-amigaos-strip
+
+USE_CLIB2=YES
+ifeq ($(USE_CLIB2), YES)
+LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/clib2
+else
+LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/newlib
+endif
 
 all:
 
@@ -39,20 +46,23 @@ jscore-native:
 	Tools/Scripts/run-javascriptcore-tests --root WebKitBuild/Release/Source/JavaScriptCore/shell/ --no-jsc-stress --no-jit-stress-test
 
 jscore-amigaos: amigaos.cmake
-	rm -rf WebKitBuild cross-build
+#rm -rf WebKitBuild cross-build
 	mkdir -p cross-build WebKitBuild/Release/bin
 	(cd cross-build && \
 		$(realpath Tools/Scripts/run-javascriptcore-tests) --jsc-only \
-		--cmakeargs='-DUSE_CLIB2=YES \
+		--cmakeargs='-DUSE_CLIB2=$(USE_CLIB2) \
 		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=$(realpath amigaos.cmake) -DCMAKE_MODULE_PATH=$(realpath Source/cmake) \
 		-DJAVASCRIPTCORE_DIR=$(realpath Source/JavaScriptCore) -DBUILD_SHARED_LIBS=NO \
-		-DICU_LIBRARY=$(SDK_PATH)/ppc-amigaos/local/clib2/lib -DICU_INCLUDE_DIR=$(SDK_PATH)/ppc-amigaos/local/clib2/include \
+		-DICU_INCLUDE_DIR=$(LIBC_PATH)/include -DICU_LIBRARIES=$(LIBC_PATH)/lib \
+		-DICU_DATA_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicudata.a \
+		-DICU_I18N_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicui18n.a \
+		-DICU_UC_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicuuc.a \
 		-DJPEG_LIBRARY=$(LIB)/libjpeg -DJPEG_INCLUDE_DIR=$(LIB)/libjpeg \
 		-DLIBXML2_LIBRARY=$(LIB)/libxml2/instdir/lib -DLIBXML2_INCLUDE_DIR=$(LIB)/libxml2/instdir/include/libxml2 \
 		-DPNG_LIBRARY=$(GEN)/libpng16/lib/ -DPNG_INCLUDE_DIR=$(GEN)/libpng16/include \
 		-DLIBXSLT_LIBRARIES=$(LIB)/libxslt/instdir/lib -DLIBXSLT_INCLUDE_DIR=$(LIB)/libxslt/instdir/include \
 		-DSQLITE_LIBRARIES=$(LIB)/sqlite/instdir/lib -DSQLITE_INCLUDE_DIR=$(LIB)/sqlite/instdir/include \
-			-DCMAKE_BUILD_TYPE=Release -DPORT=JSCOnly -DUSE_SYSTEM_MALLOC=YES \
+		-DCMAKE_BUILD_TYPE=Release -DPORT=JSCOnly -DUSE_SYSTEM_MALLOC=YES \
 		-DCMAKE_FIND_LIBRARY_SUFFIXES=".a" ')
 	cp -a Source/JavaScriptCore/API/tests/testapiScripts ./WebKitBuild/Release/Source/JavaScriptCore/shell/
 #	Tools/Scripts/run-javascriptcore-tests --root WebKitBuild/Release/Source/JavaScriptCore/shell/ --no-jsc-stress --no-jit-stress-test

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -592,7 +592,7 @@ if (CMAKE_CXX_COMPILER MATCHES ".*ppc-morphos.*")
 endif ()
 
 if (CMAKE_CXX_COMPILER MATCHES ".*ppc-amigaos.*")
-  list(APPEND WTF_LIBRARIES "-lsyscall -laboxstubs")
+    list(APPEND WTF_LIBRARIES "-use-dynld -lauto -athread=native")
 endif ()
 
 WEBKIT_FRAMEWORK_DECLARE(WTF)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -694,8 +694,10 @@ CString String::latin1() const
 #if OS(AMIGAOS)
 struct Library *CodesetsBase; struct CodesetsIFace *ICodesets;
 
-ULONG GetLength(APTR str, LONG bytes, ULONG mib)
+LONG GetLength(APTR str, LONG bytes, ULONG mib)
 {
+    if (str == NULL) return -1;
+
     return ICodesets->CodesetsStrLen((CONST_STRPTR) str,
         CSA_SourceLen, bytes,
         CSA_SourceMIBenum, mib,

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -47,6 +47,7 @@
 #ifndef MIBENUM_SYSTEM
 #define MIBENUM_SYSTEM 0xFFFFFFFF
 #endif
+#define CST_DoNotTerminate (TAG_USER + 3)
 #endif
 
 namespace WTF {
@@ -690,6 +691,42 @@ CString String::latin1() const
 }
 
 #if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(AMIGAOS)
+ULONG GetLength(APTR str, LONG bytes, ULONG mib)
+{
+    return ICodesets->CodesetsStrLen((CONST_STRPTR) str,
+        CSA_SourceLen, bytes,
+        CSA_SourceMIBenum, mib,
+        TAG_DONE
+    );
+}
+
+LONG ConvertTagList(APTR src, LONG srcbytes, APTR dst, LONG dstbytes,
+   ULONG srcmib, ULONG dstmib, CONST struct TagItem *taglist)
+{
+    STRPTR convertedString = ICodesets->CodesetsConvertStr(
+        CSA_Source, (STRPTR) src,
+        CSA_SourceLen, (ULONG) srcbytes,
+        CSA_DestLenPtr, &dstbytes,
+        CSA_SourceMIBenum, srcmib,
+        CSA_DestMIBenum, dstmib,
+        TAG_DONE
+    );
+    if (convertedString)
+    {
+        dst = convertedString;
+        ICodesets->CodesetsFreeA(convertedString, NULL);
+
+        if ((srcbytes == 0) || (dstbytes == 0))
+        {
+            return 0;
+        }
+        return dstbytes;
+    }
+    return -1;
+}
+#endif
+
 String::String(const char * characters, unsigned inlength, unsigned mib)
 {
 	if (characters)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -692,6 +692,8 @@ CString String::latin1() const
 
 #if OS(MORPHOS) || OS(AMIGAOS)
 #if OS(AMIGAOS)
+struct Library *CodesetsBase; struct CodesetsIFace *ICodesets;
+
 ULONG GetLength(APTR str, LONG bytes, ULONG mib)
 {
     return ICodesets->CodesetsStrLen((CONST_STRPTR) str,


### PR DESCRIPTION
Added the missing GetLength() and ConvertTagList() methods based on the description of the MorphOS SDK charset.doc  autodoc. I used equivalent  methods from the codesets library, trying to cover the way those methods work.

These are used only when we compile for AmigaOS 4, keeping the code as clean as possible.