### PR TITLE
Js core fixes 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ WebKitty.xcodeproj/project.xcworkspace/xcuserdata
 *_notes.md
 __cmake_systeminformation
 amigaos.cmake
+WebKitBuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ ADD . /opt/code/webkitty
 WORKDIR /opt/code/webkitty
 
 # The following steps can be changed to get the final build binaries
-RUN make jscore-amigaos
+RUN make Dummy/libdummy.a && \
+	cp Dummy/libdl.a /opt/sdk/ppc-amigaos/local/clib2/lib/ && \
+	make jscore-amigaos
 
 FROM scratch AS export-stage
 COPY --from=build-stage /opt/code/webkitty /

--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,9 @@ $(CMAKE):
 	(cd cmake-3.16.2 && make -j$(shell nproc))
 
 Dummy/libdummy.a:
-	ppc-morphos-gcc-9 -c -o Dummy/dummy.o Dummy/dummy.c
-	ppc-morphos-ar rc Dummy/libdummy.a Dummy/dummy.o
-	ppc-morphos-ranlib Dummy/libdummy.a
+	ppc-amigaos-gcc -c -o Dummy/dummy.o Dummy/dummy.c
+	ppc-amigaos-ar rc Dummy/libdummy.a Dummy/dummy.o
+	ppc-amigaos-ranlib Dummy/libdummy.a
 	cp Dummy/libdummy.a Dummy/libdl.a
 
 ffmpeg/.buildstamp:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 ROOTPATH:=$(abspath ../../sdk/)
-LIB:=$(ROOTPATH)/lib
+# LIB:=$(ROOTPATH)/lib
 GEN:=$(ROOTPATH)/gen/host/libnix
 
-PKG_ICU:=$(LIB)/libicu67/instdir/lib/pkgconfig/
-PKG_SQLITE:=$(LIB)/sqlite/instdir/lib/pkgconfig/
+# PKG_ICU:=$(LIB)/libicu67/instdir/lib/pkgconfig/
+# PKG_SQLITE:=$(LIB)/sqlite/instdir/lib/pkgconfig/
 PKG_FONTCONFIG:=$(ROOTPATH)/morphoswb/libs/fontconfig/MorphOS/
 PKG:=$(PKG_ICU):$(PKG_SQLITE)
 
@@ -21,6 +21,8 @@ LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/clib2
 else
 LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/newlib
 endif
+	
+LIB:=$(LIBC_PATH)/lib
 
 all:
 
@@ -84,12 +86,12 @@ jscore-pack:
 		./WebKitBuild/Release/Source/JavaScriptCore/shell/testmasm \
 		 JSTests LayoutTests PerformanceTests
 
-configure: morphos.cmake link.sh CMakeLists.txt Dummy/libdummy.a ffmpeg/.buildstamp
+configure: amigaos.cmake link.sh CMakeLists.txt Dummy/libdummy.a ffmpeg/.buildstamp
 	rm -rf cross-build
 	mkdir cross-build
 	(cd cross-build && PKG_CONFIG_PATH=$(PKG) PATH=$(CMAKE):${PATH} \
-		cmake -DCMAKE_CROSSCOMPILING=ON -DCMAKE_BUILD_TYPE=RelWithDebugInfo -DCMAKE_TOOLCHAIN_FILE=$(realpath morphos.cmake) -DCMAKE_DL_LIBS="syscall" \
-		-DBUILD_SHARED_LIBS=NO -DPORT=MorphOS -DENABLE_WEBCORE=1 -DENABLE_WEBKIT_LEGACY=1 -DLOG_DISABLED=0 -DMORPHOS_MINIMAL=0 -DROOTPATH="$(ROOTPATH)" \
+		cmake -DCMAKE_CROSSCOMPILING=ON -DCMAKE_BUILD_TYPE=RelWithDebugInfo -DCMAKE_TOOLCHAIN_FILE=$(realpath amigaos.cmake) -DCMAKE_DL_LIBS="syscall" \
+		-DBUILD_SHARED_LIBS=NO -DPORT=AMIGAOS -DENABLE_WEBCORE=1 -DENABLE_WEBKIT_LEGACY=1 -DLOG_DISABLED=0 -DAMIGAOS_MINIMAL=0 -DROOTPATH="$(ROOTPATH)" \
 		-DJPEG_LIBRARY=$(LIB)/libjpeg/libjpeg.a \
 		-DJPEG_INCLUDE_DIR=$(LIB)/libjpeg \
 		-DLIBXML2_LIBRARY=$(LIB)/libxml2/instdir/lib/libxml2.a \
@@ -103,10 +105,10 @@ configure: morphos.cmake link.sh CMakeLists.txt Dummy/libdummy.a ffmpeg/.buildst
 		-DSQLITE_INCLUDE_DIR=$(LIB)/sqlite/instdir/include \
 		-DSQLite3_LIBRARY=$(LIB)/sqlite/instdir/include \
 		-DSQLite3_INCLUDE_DIR=$(LIB)/sqlite/instdir/include \
-		-DCAIRO_INCLUDE_DIRS=$(ROOTPATH)/morphoswb/libs/cairo/MorphOS/os-include/cairo \
-		-DCAIRO_LIBRARIES="$(ROOTPATH)/morphoswb/libs/cairo/MorphOS/lib/libnix/libcairo.a" \
-		-DCairo_INCLUDE_DIR=$(ROOTPATH)/morphoswb/libs/cairo/MorphOS/os-include/cairo \
-		-DCairo_LIBRARY="$(ROOTPATH)/morphoswb/libs/cairo/MorphOS/lib/libnix/libcairo.a" \
+		-DCAIRO_INCLUDE_DIRS=$(ROOTPATH)/amigaoswb/libs/cairo/AmigaOS/os-include/cairo \
+		-DCAIRO_LIBRARIES="$(ROOTPATH)/amigaoswb/libs/cairo/AmigaOS/lib/libnix/libcairo.a" \
+		-DCairo_INCLUDE_DIR=$(ROOTPATH)/amigaoswb/libs/cairo/AmigaOS/os-include/cairo \
+		-DCairo_LIBRARY="$(ROOTPATH)/amigaoswb/libs/cairo/AmigaOS/lib/libnix/libcairo.a" \
 		-DHarfBuzz_INCLUDE_DIR="$(realpath Dummy)"\
 		-DHarfBuzz_LIBRARY=$(GEN)/lib/libnghttp2.a \
 		-DICU_ROOT="$(LIB)/libicu67/instdir/" \
@@ -114,10 +116,10 @@ configure: morphos.cmake link.sh CMakeLists.txt Dummy/libdummy.a ffmpeg/.buildst
 		-DICU_DATA_LIBRARY_RELEASE="$(LIB)/libicu67/instdir/lib/libicudata.a" \
 		-DICU_I18N_LIBRARY_RELEASE="$(LIB)/libicu67/instdir/lib/libicui18n.a" \
 		-DHarfBuzz_ICU_LIBRARY="$(realpath Dummy)/libdummy.a" \
-		-DFREETYPE_INCLUDE_DIRS="$(ROOTPATH)/morphoswb/libs/freetype/include" \
-		-DFREETYPE_LIBRARY="$(ROOTPATH)/morphoswb/libs/freetype/library/lib/libfreetype.a" \
-		-DFontconfig_LIBRARY="$(ROOTPATH)/morphoswb/libs/fontconfig/MorphOS/libfontconfig-glue.a" \
-		-DFontconfig_INCLUDE_DIR="$(ROOTPATH)/morphoswb/libs/fontconfig" \
+		-DFREETYPE_INCLUDE_DIRS="$(ROOTPATH)/amigaoswb/libs/freetype/include" \
+		-DFREETYPE_LIBRARY="$(ROOTPATH)/amigaoswb/libs/freetype/library/lib/libfreetype.a" \
+		-DFontconfig_LIBRARY="$(ROOTPATH)/amigaoswb/libs/fontconfig/MorphOS/libfontconfig-glue.a" \
+		-DFontconfig_INCLUDE_DIR="$(ROOTPATH)/amigaoswb/libs/fontconfig" \
 		-DOpenJPEG_INCLUDE_DIR="$(GEN)/include/openjpeg-2.5" \
 		-DWebP_INCLUDE_DIR="$(GEN)/include" -DWebP_LIBRARY="$(GEN)/lib/libwebp.a" -DWebP_DEMUX_LIBRARY="$(GEN)/lib/libwebpdemux.a"\
 		-DAVFORMAT_LIBRARY="ffmpeg/instdir/lib/libavformat.a" -DAVFORMAT_INCLUDE_DIR="$(realpath ffmpeg/instdir/include)" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOTPATH:=$(abspath ../../../)
+ROOTPATH:=$(abspath ../../sdk/)
 LIB:=$(ROOTPATH)/lib
 GEN:=$(ROOTPATH)/gen/host/libnix
 
@@ -14,6 +14,13 @@ OBJC:=$(ROOTPATH)/morphoswb/classes/frameworks/includes/
 
 CMAKE = cmake
 STRIP = ppc-amigaos-strip
+
+USE_CLIB2=YES
+ifeq ($(USE_CLIB2), YES)
+LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/clib2
+else
+LIBC_PATH=$(SDK_PATH)/ppc-amigaos/local/newlib
+endif
 
 all:
 
@@ -39,20 +46,23 @@ jscore-native:
 	Tools/Scripts/run-javascriptcore-tests --root WebKitBuild/Release/Source/JavaScriptCore/shell/ --no-jsc-stress --no-jit-stress-test
 
 jscore-amigaos: amigaos.cmake
-	rm -rf WebKitBuild cross-build
+#rm -rf WebKitBuild cross-build
 	mkdir -p cross-build WebKitBuild/Release/bin
 	(cd cross-build && \
 		$(realpath Tools/Scripts/run-javascriptcore-tests) --jsc-only \
-		--cmakeargs='-DUSE_CLIB2=YES \
+		--cmakeargs='-DUSE_CLIB2=$(USE_CLIB2) \
 		-DCMAKE_CROSSCOMPILING=ON -DCMAKE_TOOLCHAIN_FILE=$(realpath amigaos.cmake) -DCMAKE_MODULE_PATH=$(realpath Source/cmake) \
 		-DJAVASCRIPTCORE_DIR=$(realpath Source/JavaScriptCore) -DBUILD_SHARED_LIBS=NO \
-		-DICU_LIBRARY=$(SDK_PATH)/ppc-amigaos/local/clib2/lib -DICU_INCLUDE_DIR=$(SDK_PATH)/ppc-amigaos/local/clib2/include \
+		-DICU_INCLUDE_DIR=$(LIBC_PATH)/include -DICU_LIBRARIES=$(LIBC_PATH)/lib \
+		-DICU_DATA_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicudata.a \
+		-DICU_I18N_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicui18n.a \
+		-DICU_UC_LIBRARY_RELEASE=$(LIBC_PATH)/lib/libicuuc.a \
 		-DJPEG_LIBRARY=$(LIB)/libjpeg -DJPEG_INCLUDE_DIR=$(LIB)/libjpeg \
 		-DLIBXML2_LIBRARY=$(LIB)/libxml2/instdir/lib -DLIBXML2_INCLUDE_DIR=$(LIB)/libxml2/instdir/include/libxml2 \
 		-DPNG_LIBRARY=$(GEN)/libpng16/lib/ -DPNG_INCLUDE_DIR=$(GEN)/libpng16/include \
 		-DLIBXSLT_LIBRARIES=$(LIB)/libxslt/instdir/lib -DLIBXSLT_INCLUDE_DIR=$(LIB)/libxslt/instdir/include \
 		-DSQLITE_LIBRARIES=$(LIB)/sqlite/instdir/lib -DSQLITE_INCLUDE_DIR=$(LIB)/sqlite/instdir/include \
-			-DCMAKE_BUILD_TYPE=Release -DPORT=JSCOnly -DUSE_SYSTEM_MALLOC=YES \
+		-DCMAKE_BUILD_TYPE=Release -DPORT=JSCOnly -DUSE_SYSTEM_MALLOC=YES \
 		-DCMAKE_FIND_LIBRARY_SUFFIXES=".a" ')
 	cp -a Source/JavaScriptCore/API/tests/testapiScripts ./WebKitBuild/Release/Source/JavaScriptCore/shell/
 #	Tools/Scripts/run-javascriptcore-tests --root WebKitBuild/Release/Source/JavaScriptCore/shell/ --no-jsc-stress --no-jit-stress-test

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1385,7 +1385,11 @@ static void testCFStrings(void)
 }
 #endif
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char* argv[])
+#else
 int main(int argc, char* argv[])
+#endif
 {
 #if OS(WINDOWS)
     // Cygwin calls SetErrorMode(SEM_FAILCRITICALERRORS), which we will inherit. This is bad for

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -5958,7 +5958,11 @@ static void run(const char*)
 
 #endif // ENABLE(JIT)
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
     const char* filter = nullptr;
     switch (argc) {

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -2534,7 +2534,11 @@ static void run(const char*)
 
 #endif // ENABLE(B3_JIT)
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
     const char* filter = nullptr;
     switch (argc) {

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -903,7 +903,11 @@ extern const JSC::JITOperationAnnotation startOfJITOperationsInTestB3 __asm("sec
 extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm("section$end$__DATA_CONST$__jsc_ops");
 #endif
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
     const char* filter = nullptr;
     switch (argc) {

--- a/Source/JavaScriptCore/dfg/testdfg.cpp
+++ b/Source/JavaScriptCore/dfg/testdfg.cpp
@@ -101,7 +101,11 @@ static void run(const char*)
 
 #endif // ENABLE(DFG_JIT)
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
     const char* filter = nullptr;
     switch (argc) {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2973,7 +2973,11 @@ static void startTimeoutThreadIfNeeded(VM& vm)
     startTimeoutTimer(timeoutDuration);
 }
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int argc, char** argv)
+#else
 int main(int argc, char** argv)
+#endif
 {
 #if OS(DARWIN) && CPU(ARM_THUMB2)
     // Enabled IEEE754 denormal support.

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -117,7 +117,11 @@ const int64_t* LLIntOffsetsExtractor::dummy()
 
 } // namespace JSC
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int, char**)
+#else
 int main(int, char**)
+#endif
 {
     // Out of an abundance of caution, make sure that LLIntOffsetsExtractor::dummy() is live,
     // and the extractorTable is live, too.

--- a/Source/JavaScriptCore/llint/LLIntSettingsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSettingsExtractor.cpp
@@ -28,7 +28,11 @@
 #include "LLIntOfflineAsmConfig.h"
 #include <stdio.h>
 
+#if OS(AMIGAOS)
+__attribute__((visibility("default"))) int main(int, char**)
+#else
 int main(int, char**)
+#endif
 {
 #include "LLIntDesiredSettings.h"
     printf("%p\n", settingsExtractorTable);

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -67,7 +67,7 @@
 #import <wtf/spi/cocoa/OSLogSPI.h>
 #endif
 
-#if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(MORPHOS)
 extern "C" { void vdprintf(const char *, va_list); }
 #endif
 
@@ -184,7 +184,7 @@ static void vprintf_stderr_common(const char* format, va_list args)
         } while (size > 1024);
     }
 #endif
-#if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(MORPHOS)
 	vdprintf(format, args);
 	return;
 #endif

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -69,7 +69,7 @@ extern "C" void _ReadWriteBarrier(void);
 #endif
 #endif
 
-#if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(MORPHOS)
 extern "C" { void dprintf(const char *, ...); }
 #endif
 
@@ -652,7 +652,7 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 
 #if !ASSERT_ENABLED
 
-#if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(MORPHOS)
 #define RELEASE_ASSERT(assertion, ...) do { \
     if (UNLIKELY(!(assertion))) { \
         dprintf("WTFReleaseAssert in %s/%d\n", __FILE__, __LINE__); CRASH(); \

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -592,7 +592,7 @@ if (CMAKE_CXX_COMPILER MATCHES ".*ppc-morphos.*")
 endif ()
 
 if (CMAKE_CXX_COMPILER MATCHES ".*ppc-amigaos.*")
-  list(APPEND WTF_LIBRARIES "-lsyscall -laboxstubs")
+    list(APPEND WTF_LIBRARIES "-use-dynld -lauto -athread=native")
 endif ()
 
 WEBKIT_FRAMEWORK_DECLARE(WTF)

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -592,7 +592,7 @@ if (CMAKE_CXX_COMPILER MATCHES ".*ppc-morphos.*")
 endif ()
 
 if (CMAKE_CXX_COMPILER MATCHES ".*ppc-amigaos.*")
-    list(APPEND WTF_LIBRARIES "-use-dynld -lauto -athread=native")
+    list(APPEND WTF_LIBRARIES "-lauto -athread=native")
 endif ()
 
 WEBKIT_FRAMEWORK_DECLARE(WTF)

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -50,9 +50,15 @@
 #include <notify.h>
 #endif
 
-#if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(MORPHOS)
 #include <cstdint>
 extern "C" { void dprintf(const char *,... ); }
+#undef CRASH
+extern "C" { void _oomCrash() { std::abort(); }; void oomCrash() __attribute__((weak, alias ("_oomCrash"))); }
+#define CRASH oomCrash
+#endif
+
+#if OS(AMIGAOS)
 #undef CRASH
 extern "C" { void _oomCrash() { std::abort(); }; void oomCrash() __attribute__((weak, alias ("_oomCrash"))); }
 #define CRASH oomCrash

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -116,7 +116,8 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 else ()
     list(APPEND WTF_SOURCES
         generic/MemoryFootprintGeneric.cpp
-        generic/MemoryPressureHandlerGeneric.cpp
+        morphos/MemoryPressureHandlerMorphOS.cpp
+        # generic/MemoryPressureHandlerGeneric.cpp
     )
 endif ()
 

--- a/Source/WTF/wtf/morphos/MemoryPressureHandlerMorphOS.cpp
+++ b/Source/WTF/wtf/morphos/MemoryPressureHandlerMorphOS.cpp
@@ -34,7 +34,9 @@
 #endif
 #include <exec/memory.h>
 
+#if !OS(AMIGAOS)
 extern "C" { void dprintf(const char *,...); }
+#endif
 
 namespace WebKit {
 	extern void reactOnMemoryPressureInWebKit();

--- a/Source/WTF/wtf/morphos/MemoryPressureHandlerMorphOS.cpp
+++ b/Source/WTF/wtf/morphos/MemoryPressureHandlerMorphOS.cpp
@@ -25,7 +25,13 @@
 
 #include "config.h"
 #include <wtf/MemoryPressureHandler.h>
+#if OS(AMIGAOS)
+#define __USE_INLINE__
+#endif
 #include <proto/exec.h>
+#if OS(AMIGAOS)
+#undef __USE_INLINE__
+#endif
 #include <exec/memory.h>
 
 extern "C" { void dprintf(const char *,...); }
@@ -74,10 +80,11 @@ void MemoryPressureHandler::morphosMeasurementTimerFired()
 	
 	if (memoryLow)
 	{
-        setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
-        releaseMemory(Critical::Yes);
-        WebKit::reactOnMemoryPressureInWebKit();
-        return;
+		setMemoryPressureStatus(MemoryPressureStatus::SystemCritical);
+		releaseMemory(Critical::Yes);
+		// TODO:This possible needs to be enabled when we build the WebKit fully
+		// WebKit::reactOnMemoryPressureInWebKit();
+		return;
 	}
 }
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -694,8 +694,10 @@ CString String::latin1() const
 #if OS(AMIGAOS)
 struct Library *CodesetsBase; struct CodesetsIFace *ICodesets;
 
-ULONG GetLength(APTR str, LONG bytes, ULONG mib)
+LONG GetLength(APTR str, LONG bytes, ULONG mib)
 {
+    if (str == NULL) return -1;
+
     return ICodesets->CodesetsStrLen((CONST_STRPTR) str,
         CSA_SourceLen, bytes,
         CSA_SourceMIBenum, mib,

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -47,6 +47,7 @@
 #ifndef MIBENUM_SYSTEM
 #define MIBENUM_SYSTEM 0xFFFFFFFF
 #endif
+#define CST_DoNotTerminate (TAG_USER + 3)
 #endif
 
 namespace WTF {
@@ -690,6 +691,42 @@ CString String::latin1() const
 }
 
 #if OS(MORPHOS) || OS(AMIGAOS)
+#if OS(AMIGAOS)
+ULONG GetLength(APTR str, LONG bytes, ULONG mib)
+{
+    return ICodesets->CodesetsStrLen((CONST_STRPTR) str,
+        CSA_SourceLen, bytes,
+        CSA_SourceMIBenum, mib,
+        TAG_DONE
+    );
+}
+
+LONG ConvertTagList(APTR src, LONG srcbytes, APTR dst, LONG dstbytes,
+   ULONG srcmib, ULONG dstmib, CONST struct TagItem *taglist)
+{
+    STRPTR convertedString = ICodesets->CodesetsConvertStr(
+        CSA_Source, (STRPTR) src,
+        CSA_SourceLen, (ULONG) srcbytes,
+        CSA_DestLenPtr, &dstbytes,
+        CSA_SourceMIBenum, srcmib,
+        CSA_DestMIBenum, dstmib,
+        TAG_DONE
+    );
+    if (convertedString)
+    {
+        dst = convertedString;
+        ICodesets->CodesetsFreeA(convertedString, NULL);
+
+        if ((srcbytes == 0) || (dstbytes == 0))
+        {
+            return 0;
+        }
+        return dstbytes;
+    }
+    return -1;
+}
+#endif
+
 String::String(const char * characters, unsigned inlength, unsigned mib)
 {
 	if (characters)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -692,6 +692,8 @@ CString String::latin1() const
 
 #if OS(MORPHOS) || OS(AMIGAOS)
 #if OS(AMIGAOS)
+struct Library *CodesetsBase; struct CodesetsIFace *ICodesets;
+
 ULONG GetLength(APTR str, LONG bytes, ULONG mib)
 {
     return ICodesets->CodesetsStrLen((CONST_STRPTR) str,

--- a/amigaos.cmake.in
+++ b/amigaos.cmake.in
@@ -5,12 +5,12 @@ SET(CMAKE_SYSTEM_PROCESSOR ppc)
 SET(CMAKE_C_COMPILER /opt/ppc-amigaos/bin/ppc-amigaos-gcc)
 SET(CMAKE_CXX_COMPILER /opt/ppc-amigaos/bin/ppc-amigaos-g++)
 
-SET(CMAKE_CXX_FLAGS "-O3 -DNDEBUG -g0 -gstabs1 -feliminate-unused-debug-symbols -mlongcall -mno-sched-prolog -Wno-ignored-attributes -Wno-unused-but-set-parameter")
+SET(CMAKE_CXX_FLAGS "-mcrt=clib2 -O3 -DNDEBUG -g0 -gstabs1 -feliminate-unused-debug-symbols -mlongcall -mno-sched-prolog -Wno-ignored-attributes -Wno-unused-but-set-parameter")
 SET(CMAKE_CXX_FLAGS_RELEASE "")
 SET(CMAKE_CXX_FLAGS_DEBUG "-mlongcall -mno-sched-prolog -Wno-ignored-attributes -Wno-unused-but-set-parameter")
 SET(CMAKE_CXX_FLAGS_RELEASE_INIT "")
 
-SET(CMAKE_C_FLAGS "-O3 -mlongcall -mno-sched-prolog -Wno-ignored-attributes")
+SET(CMAKE_C_FLAGS "-mcrt=clib2 -O3 -mlongcall -mno-sched-prolog -Wno-ignored-attributes")
 SET(CMAKE_C_FLAGS_DEBUG "-mlongcall -mno-sched-prolog -Wno-ignored-attributes")
 
 SET(CMAKE_MODULE_LINKER_FLAGS "-lpthread -athread=native")


### PR DESCRIPTION
This a few changes for keeping the JSCore native to compile. These changes tackle the problem with the error

`undefined reference to _ZN3WTF21MemoryPressureHandler28morphosMeasurementTimerFiredEv`

based on my findings at https://github.com/walkero-gr/webkitty/issues/7#issuecomment-1351388355

Have in mind that it includes the work done in https://github.com/walkero-gr/webkitty/pull/10 since that is not merged yet.