### PR TITLE
Addition of CI/CD

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,9 @@ kind: pipeline
 type: docker
 name: compile-jsc
 
+clone:
+  depth: 10
+
 workspace:
   path: /drone/src
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,8 +76,7 @@ steps:
     - curl -sw "\n" "http://10.0.0.2:5000/container/count/drone-" | while read var1; do if [ $var1 -eq 1 ]; then hcloud server poweroff drone-agents; fi ; done
 
 depends_on:
-  - compile-tests
-  - compile-release-bytag
+  - compile-jsc
 
 trigger:
   status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,94 @@
+kind: pipeline
+type: docker
+name: drone-agents-poweron
+
+clone:
+  disable: true
+
+steps:
+- name: drone-agents-poweron
+  image: walkero/hcloud:1.30
+  environment:
+    HCLOUD_TOKEN:
+      from_secret: HCLOUD_TOKEN
+  commands:
+    - hcloud server poweron drone-agents
+
+trigger:
+  branch:
+    include:
+    - master
+    - develop
+  event:
+    include:
+    - push
+    - pull_request
+    - tag
+
+---
+
+kind: pipeline
+type: docker
+name: compile-jsc
+
+workspace:
+  path: /drone/src
+
+steps:
+- name: with-clib2
+  pull: always
+  image: walkero/webkitondocker
+  commands:
+  - make -f Makefile jscore-amigaos
+
+trigger:
+  branch:
+    include:
+    - amigaos_*
+    - ci-cd
+  event:
+    include:
+    - push
+    - pull_request
+
+depends_on:
+  - drone-agents-poweron
+
+node:
+  agents: builders
+
+---
+
+kind: pipeline
+type: docker
+name: drone-agents-poweroff
+
+clone:
+  disable: true
+
+steps:
+- name: drone-agents-poweroff
+  image: walkero/hcloud:1.30
+  environment:
+    HCLOUD_TOKEN:
+      from_secret: HCLOUD_TOKEN
+  commands:
+    - curl -sw "\n" "http://10.0.0.2:5000/container/count/drone-" | while read var1; do if [ $var1 -eq 1 ]; then hcloud server poweroff drone-agents; fi ; done
+
+depends_on:
+  - compile-tests
+  - compile-release-bytag
+
+trigger:
+  status:
+    - failure
+    - success
+  branch:
+    include:
+    - master
+    - develop
+  event:
+    include:
+    - push
+    - pull_request
+    - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,10 +32,10 @@ type: docker
 name: compile-jsc
 
 clone:
-  depth: 10
+  depth: 5
 
 workspace:
-  path: /drone/src
+  path: /opt/code/webkitty
 
 steps:
 - name: with-clib2

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,8 +17,8 @@ steps:
 trigger:
   branch:
     include:
-    - master
-    - develop
+    - amigaos_*
+    - ci-cd
   event:
     include:
     - push
@@ -84,8 +84,8 @@ trigger:
     - success
   branch:
     include:
-    - master
-    - develop
+    - amigaos_*
+    - ci-cd
   event:
     include:
     - push

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+[![Build Status](https://drone-gh.intercube.gr/api/badges/walkero-gr/webkitty/status.svg)](https://drone-gh.intercube.gr/walkero-gr/webkitty)
+
+# webkitty for AmigaOS 4
+
+This repository is a fork of https://github.com/jacadcaps/webkitty and the work we do here is to port the WebKit GTK to AmigaOS 4 based on the work that was done on MorphOS.
+
+This is necessary for building a new up-to-date browser.
+
+You can follow our work at
+- https://github.com/users/walkero-gr/projects/1/views/1
+- https://github.com/walkero-gr/webkitty/issues
+- https://www.amigans.net/modules/newbb/viewtopic.php?topic_id=8986


### PR DESCRIPTION
This is for setting up automated builds on docker using CI/CD, whenever a Pull Request or a merge is created.
This builds the JSC with clib2 for now, but we can extend it in the future adding more steps if needed.