### PR TITLE
Fix  missing } for WebCore namespace in Image.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -404,3 +404,5 @@ Ref<Image> Image::loadPlatformResource(const char* resource)
 }
 
 #endif // !PLATFORM(COCOA) && !PLATFORM(GTK) && !PLATFORM(WIN) && !OS(MORPHOS) && !OS(AMIGAOS)
+
+} // namespace WebCore


### PR DESCRIPTION
Fixed missining } at the end of platforms/graphics/Image.cpp , to close namespace WebCore, which previously cause massive set of compiling errors.