### PR TITLE
More fixes to build-mini (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ configure-mini: amigaos.cmake link.sh CMakeLists.txt Dummy/libdummy.a ffmpeg/.bu
 		$(realpath ./))
 
 build:
-	(cd cross-build && make -j1)
+	(cd cross-build && make -j$(shell nproc))
 	echo "Link done"
 	$(STRIP) cross-build/Tools/morphos/MiniBrowser.db -o cross-build/Tools/morphos/MiniBrowser
 	echo "Stripped binary in cross-build/Tools/morphos/MiniBrowser"
@@ -145,7 +145,7 @@ build:
 #		-Wdev --debug-output --trace --trace-expand \
 
 build-mini:
-	(cd cross-build-mini && make -j1)
+	(cd cross-build-mini && make -j$(shell nproc))
 
 cross-build:
 	make configure
@@ -182,7 +182,7 @@ $(CMAKE):
 	rm -rf cmake-3.16.2
 	tar xf cmake-3.16.2.tar.gz
 	(cd cmake-3.16.2 && ./bootstrap -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL=OFF )
-	(cd cmake-3.16.2 && make -j1)
+	(cd cmake-3.16.2 && make -j$(shell nproc))
 
 Dummy/libdummy.a:
 	ppc-amigaos-gcc -c -o Dummy/dummy.o Dummy/dummy.c

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -404,3 +404,5 @@ Ref<Image> Image::loadPlatformResource(const char* resource)
 }
 
 #endif // !PLATFORM(COCOA) && !PLATFORM(GTK) && !PLATFORM(WIN) && !OS(MORPHOS) && !OS(AMIGAOS)
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -32,7 +32,6 @@
 #include "ImageBufferUtilitiesCairo.h"
 
 #if USE(CAIRO)
-#error "USING CAIRO... GREAT"
 
 #include "CairoUtilities.h"
 #include "MIMETypeRegistry.h"
@@ -58,7 +57,6 @@
 // #undef __USE_INLINE__
 #include <string.h>
 #if OS(MORPHOS)
-#error "IS MORPHOS SET?"
 #include <proto/random.h>
 // TODO: Decide if this is needed
 // #else

--- a/Source/WebKitLegacy/PlatformAmigaOS.cmake
+++ b/Source/WebKitLegacy/PlatformAmigaOS.cmake
@@ -42,29 +42,29 @@ list(APPEND WebKitLegacy_SOURCES_Classes
     morphos/NetworkSession.cpp
 )
 
-list(APPEND WebKitLegacy_SOURCES_Classes
-    morphos/WkWebView.mm
-    morphos/WkNetworkRequestMutable.mm
-    morphos/WkHistory.mm
-    morphos/WkSettings.mm
-    morphos/WkCertificate.mm
-    morphos/WkCertificateViewer.mm
-    morphos/WkError.mm
-    morphos/WkDownload.mm
-    morphos/WkFileDialog.mm
-    morphos/WkHitTest.mm
-    morphos/WkFavIcon.mm
-    morphos/WkPrinting.mm
-    morphos/WkUserScript.mm
-    morphos/WkMedia.mm
-    morphos/WkNotification.mm
-    morphos/WkResourceResponse.mm
-    morphos/WkCache.mm
-)
+# list(APPEND WebKitLegacy_SOURCES_Classes
+#     morphos/WkWebView.mm
+#     morphos/WkNetworkRequestMutable.mm
+#     morphos/WkHistory.mm
+#     morphos/WkSettings.mm
+#     morphos/WkCertificate.mm
+#     morphos/WkCertificateViewer.mm
+#     morphos/WkError.mm
+#     morphos/WkDownload.mm
+#     morphos/WkFileDialog.mm
+#     morphos/WkHitTest.mm
+#     morphos/WkFavIcon.mm
+#     morphos/WkPrinting.mm
+#     morphos/WkUserScript.mm
+#     morphos/WkMedia.mm
+#     morphos/WkNotification.mm
+#     morphos/WkResourceResponse.mm
+#     morphos/WkCache.mm
+# )
 
 list(APPEND WebKitLegacy_SOURCES_WebCoreSupport
     morphos/WebCoreSupport/WebVisitedLinkStore.cpp
-    morphos/WebCoreSupport/WebEditorClient.cpp
+    # morphos/WebCoreSupport/WebEditorClient.cpp
     morphos/WebCoreSupport/WebChromeClient.cpp
     morphos/WebCoreSupport/WebPluginInfoProvider.cpp
     morphos/WebCoreSupport/WebPlatformStrategies.cpp
@@ -77,26 +77,26 @@ list(APPEND WebKitLegacy_SOURCES_WebCoreSupport
     morphos/WebCoreSupport/WebNotificationClient.cpp
 )
 
-list(APPEND WebKitLegacy_SOURCES_WebCoreSupport
-    morphos/cache/CacheStorageEngine.cpp
-    morphos/cache/CacheStorageEngineCache.cpp
-    morphos/cache/CacheStorageEngineCaches.cpp
-    morphos/cache/NetworkCacheCoders.cpp
-    morphos/cache/NetworkCacheDataCurl.cpp
-    morphos/cache/NetworkCacheIOChannelCurl.cpp
-    morphos/cache/NetworkCacheSubresourcesEntry.cpp
-    morphos/cache/NetworkCacheBlobStorage.cpp
-    morphos/cache/NetworkCacheEntry.cpp
-    morphos/cache/NetworkCacheKey.cpp
-    morphos/cache/PrefetchCache.cpp
-    morphos/cache/NetworkCacheData.cpp
-    morphos/cache/NetworkCacheFileSystem.cpp
-    morphos/cache/NetworkCacheStorage.cpp
-    morphos/cache/NetworkCache.cpp
-    morphos/cache/CacheStorageEngineConnection.cpp
-    morphos/cache/WebCacheStorageProvider.cpp
-    morphos/cache/WebCacheStorageConnection.cpp
-    )
+# list(APPEND WebKitLegacy_SOURCES_WebCoreSupport
+#     morphos/cache/CacheStorageEngine.cpp
+#     morphos/cache/CacheStorageEngineCache.cpp
+#     morphos/cache/CacheStorageEngineCaches.cpp
+#     morphos/cache/NetworkCacheCoders.cpp
+#     morphos/cache/NetworkCacheDataCurl.cpp
+#     morphos/cache/NetworkCacheIOChannelCurl.cpp
+#     morphos/cache/NetworkCacheSubresourcesEntry.cpp
+#     morphos/cache/NetworkCacheBlobStorage.cpp
+#     morphos/cache/NetworkCacheEntry.cpp
+#     morphos/cache/NetworkCacheKey.cpp
+#     morphos/cache/PrefetchCache.cpp
+#     morphos/cache/NetworkCacheData.cpp
+#     morphos/cache/NetworkCacheFileSystem.cpp
+#     morphos/cache/NetworkCacheStorage.cpp
+#     morphos/cache/NetworkCache.cpp
+#     morphos/cache/CacheStorageEngineConnection.cpp
+#     morphos/cache/WebCacheStorageProvider.cpp
+#     morphos/cache/WebCacheStorageConnection.cpp
+#     )
 
 if (NOT AMIGAOS_MINIMAL)
 	list(APPEND WebKitLegacy_ABP
@@ -127,25 +127,25 @@ endif()
 
 list(APPEND WebKitLegacy_SOURCES ${WebKitLegacy_INCLUDES} ${WebKitLegacy_SOURCES_Classes} ${WebKitLegacy_SOURCES_WebCoreSupport} ${WebKitLegacy_ABP})
 
-set(MM_FLAGS "-Wno-ignored-attributes -Wno-protocol -Wundeclared-selector -fobjc-call-cxx-cdtors -fobjc-exceptions -fconstant-string-class=OBConstantString -DDEBUG=0")
+# set(MM_FLAGS "-Wno-ignored-attributes -Wno-protocol -Wundeclared-selector -fobjc-call-cxx-cdtors -fobjc-exceptions -fconstant-string-class=OBConstantString -DDEBUG=0")
 
-set_source_files_properties(morphos/WkWebView.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkNetworkRequestMutable.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkHistory.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkSettings.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkCertificate.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkCertificateViewer.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkError.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkDownload.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkFileDialog.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkHitTest.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkFavIcon.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkPrinting.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkUserScript.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkMedia.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkNotification.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkResourceResponse.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
-set_source_files_properties(morphos/WkCache.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkWebView.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkNetworkRequestMutable.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkHistory.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkSettings.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkCertificate.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkCertificateViewer.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkError.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkDownload.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkFileDialog.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkHitTest.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkFavIcon.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkPrinting.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkUserScript.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkMedia.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkNotification.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkResourceResponse.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
+# set_source_files_properties(morphos/WkCache.mm PROPERTIES COMPILE_FLAGS ${MM_FLAGS})
 
 set(WebKitLegacy_OUTPUT_NAME
     WebKit${DEBUG_SUFFIX}

--- a/Source/WebKitLegacy/morphos/PopupMenu.cpp
+++ b/Source/WebKitLegacy/morphos/PopupMenu.cpp
@@ -4,7 +4,9 @@
 #include <WebCore/FrameView.h>
 #include <wtf/text/AtomString.h>
 
+#if !OS(AMIGAOS)
 extern "C" { void dprintf(const char *,...); }
+#endif
 
 using namespace WebCore;
 using namespace WTF;

--- a/Source/WebKitLegacy/morphos/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKitLegacy/morphos/WebCoreSupport/WebEditorClient.cpp
@@ -46,9 +46,12 @@
 #include <WebCore/UndoStep.h>
 #include <wtf/text/StringView.h>
 #include <proto/exec.h>
+#if !OS(AMIGAOS)
 #include <proto/spellchecker.h>
 #include <libraries/spellchecker.h>
+#endif
 #include <unicode/ubrk.h>
+
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wmisleading-indentation"

--- a/Source/WebKitLegacy/morphos/WebDragClient.cpp
+++ b/Source/WebKitLegacy/morphos/WebDragClient.cpp
@@ -1,7 +1,9 @@
 #include "WebDragClient.h"
 #include "WebPage.h"
 
+#if !OS(AMIGAOS)
 extern "C" { void dprintf(const char *,...); }
+#endif
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKitLegacy/morphos/WebPage.cpp
+++ b/Source/WebKitLegacy/morphos/WebPage.cpp
@@ -207,7 +207,7 @@
 #define EP_END(x)
 #define RPTAG_PenMode 0x80000080
 #define RPTAG_FgColor 0x80000081
-#define RECTFMT_ARGB  (2UL)
+#define RECTFMT_ARGB  PIXF_A8R8G8B8
 #define NM_WHEEL_UP     RAWKEY_NM_WHEEL_UP
 #define NM_WHEEL_DOWN   RAWKEY_NM_WHEEL_DOWN
 #define NM_WHEEL_LEFT   RAWKEY_NM_WHEEL_LEFT
@@ -637,7 +637,7 @@ public:
 
 		m_damage.visitDamagedTiles([&](const int x, const int y, const int width, const int height) {
 			EP_SCOPE(wpa);
-			WritePixelArray(src, x, y, stride, rp, outX + x, outY + y, width, height, RECTFMT_ARGB);
+			WritePixelArray(src, x, y, stride, RECTFMT_ARGB, rp, outX + x, outY + y, width, height);
 		});
 	}
 	
@@ -648,7 +648,7 @@ public:
 		const unsigned int stride = cairo_image_surface_get_stride(m_surface);
 		unsigned char *src = cairo_image_surface_get_data(m_surface);
 		EP_SCOPE(wpa);
-		WritePixelArray(src, 0, 0, stride, rp, outX, outY, m_width, m_height, RECTFMT_ARGB);
+		WritePixelArray(src, 0, 0, stride, RECTFMT_ARGB, rp, outX, outY, m_width, m_height);
 	}
 
 	void draw(WebCore::FrameView *frameView, RastPort *rp, const int x, const int y, const int width, const int height,
@@ -1282,7 +1282,7 @@ WebPage::WebPage(WebCore::PageIdentifier pageID, WebPageCreationParameters&& par
 
 //     settings.setStorageBlockingPolicy(SecurityOrigin::StorageBlockingPolicy::BlockAllStorage);
 	settings.setLocalStorageDatabasePath(String("PROGDIR:Cache/LocalStorage"));
-#if (!MORPHOS_MINIMAL) && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 	settings.setWebAudioEnabled(true);
 //	settings.setAudioWorkletEnabled(true);
 //	settings.setModernUnprefixedWebAudioEnabled(true);
@@ -1619,7 +1619,7 @@ bool WebPage::touchEventsEnabled() const
 	#if ENABLE(TOUCH_EVENTS)
 	return m_page->settings().isTouchEventEmulationEnabled();
 	#endif
-	return FALSE
+	return FALSE;
 }
 
 void WebPage::setTouchEventsEnabled(bool enabled)
@@ -2554,8 +2554,8 @@ void WebPage::printPreview(struct RastPort *rp, const int x, const int y, const 
 	RectFill(rp, paintX - 1, paintY - 1, paintX - 1, paintY + scaledSize.height() - 1);
 	RectFill(rp, paintX + scaledSize.width(), paintY - 1, paintX + scaledSize.width(), paintY + scaledSize.height() - 1);
 
-	WritePixelArray(src, 0, 0, stride, rp, paintX, paintY,
-		scaledSize.width(), scaledSize.height(), RECTFMT_ARGB);
+	WritePixelArray(src, 0, 0, stride, RECTFMT_ARGB, rp, paintX, paintY,
+		scaledSize.width(), scaledSize.height());
 
 }
 
@@ -2824,7 +2824,7 @@ bool WebPage::drawRect(const int x, const int y, const int width, const int heig
 		const unsigned int stride = cairo_image_surface_get_stride(surface);
 		unsigned char *src = cairo_image_surface_get_data(surface);
 
-		WritePixelArray(src, 0, 0, stride, rp, 0, 0, width, height, RECTFMT_ARGB);
+		WritePixelArray(src, 0, 0, stride, RECTFMT_ARGB, rp, 0, 0, width, height);
 	}
 
 	cairo_destroy(cairo);
@@ -3964,7 +3964,7 @@ void WebPage::drawDragImage(struct RastPort *rp, const int x, const int y, const
 	{
 		const unsigned int stride = cairo_image_surface_get_stride(imageRef.get());
 		unsigned char *src = cairo_image_surface_get_data(imageRef.get());
-		WritePixelArray(src, 0, 0, stride, rp, x, y, width, height, RECTFMT_ARGB);
+		WritePixelArray(src, 0, 0, stride, RECTFMT_ARGB, rp, x, y, width, height);
 	}
 }
 

--- a/Source/WebKitLegacy/morphos/WebPage.cpp
+++ b/Source/WebKitLegacy/morphos/WebPage.cpp
@@ -160,26 +160,62 @@
 #include <utility>
 #include <cstdio>
 
-#include <proto/graphics.h>
 #include <proto/exec.h>
-#include <proto/cybergraphics.h>
 #include <proto/intuition.h>
 #include <proto/layers.h>
+#if OS(MORPHOS)
+#include <proto/cybergraphics.h>
 #include <cybergraphx/cybergraphics.h>
+#endif
+#if OS(AMIGAOS)
+#define DOS_DOSEXTENS_H
+#define __USE_INLINE__
+#endif
 #include <proto/graphics.h>
 #include <proto/dos.h>
+#if OS(AMIGAOS)
+#undef PAL
+#undef __USE_INLINE__
+#undef DOS_DOSEXTENS_H
+#endif
 #include <dos/dos.h>
 #include <graphics/rpattr.h>
 #include <intuition/intuition.h>
 #include <intuition/pointerclass.h>
+#if OS(MORPHOS)
 #include <intuition/intuimessageclass.h>
+#endif
 #include <intuition/classusr.h>
 #include <clib/alib_protos.h>
 #include <devices/rawkeycodes.h>
+#if OS(AMIGAOS)
+#define __USE_INLINE__
+#endif
 #include <proto/openurl.h>
 #include <libraries/openurl.h>
+#if OS(AMIGAOS)
+#undef __USE_INLINE__
+#endif
 
+#if OS(MORPHOS)
 #include <libeventprofiler.h>
+#endif
+
+#if OS(AMIGAOS)
+#define EP_SCOPE(x)
+#define EP_BEGIN(x)
+#define EP_END(x)
+#define RPTAG_PenMode 0x80000080
+#define RPTAG_FgColor 0x80000081
+#define RECTFMT_ARGB  (2UL)
+#define NM_WHEEL_UP     RAWKEY_NM_WHEEL_UP
+#define NM_WHEEL_DOWN   RAWKEY_NM_WHEEL_DOWN
+#define NM_WHEEL_LEFT   RAWKEY_NM_WHEEL_LEFT
+#define NM_WHEEL_RIGHT  RAWKEY_NM_WHEEL_RIGHT
+#define POINTERTYPE_VERTICALRESIZE POINTERTYPE_COLUMNRESIZE
+#define POINTERTYPE_ALTERNATIVECHOICE POINTERTYPE_CONTEXTMENU
+#define IDCMP_MOUSEHOVER IDCMP_EXTENDEDMOUSE
+#endif
 
 // we cannot include libraries/mui.h here...
 enum
@@ -218,9 +254,11 @@ enum
 	MUIKEY_ICONIFY,
 };
 
+#if !OS(AMIGAOS)
 extern "C" {
 	void dprintf(const char *, ...);
 };
+#endif
 
 #define D(x) 
 
@@ -1218,7 +1256,9 @@ WebPage::WebPage(WebCore::PageIdentifier pageID, WebPageCreationParameters&& par
 	settings.setTextAreasAreResizable(true);
 	settings.setIntersectionObserverEnabled(true);
 	settings.setDataTransferItemsEnabled(true);
+	#if !OS(AMIGAOS)
 	settings.setDownloadAttributeEnabled(true);
+	#endif
 
 #if 1
 	settings.setForceCompositingMode(false);
@@ -1271,8 +1311,10 @@ WebPage::WebPage(WebCore::PageIdentifier pageID, WebPageCreationParameters&& par
        settings.setFullScreenEnabled(true);
 #endif
 
+#if ENABLE(TOUCH_EVENTS)
 	// the default
 	settings.setTouchEventEmulationEnabled(false);
+#endif
 
 // crashy
 //    settings.setDiagnosticLoggingEnabled(true);
@@ -1574,12 +1616,17 @@ void WebPage::setAdBlockingEnabled(bool enabled)
 
 bool WebPage::touchEventsEnabled() const
 {
+	#if ENABLE(TOUCH_EVENTS)
 	return m_page->settings().isTouchEventEmulationEnabled();
+	#endif
+	return FALSE
 }
 
 void WebPage::setTouchEventsEnabled(bool enabled)
 {
+	#if ENABLE(TOUCH_EVENTS)
 	m_page->settings().setTouchEventEmulationEnabled(enabled);
+	#endif
 }
 
 bool WebPage::thirdPartyCookiesAllowed() const

--- a/Source/WebKitLegacy/morphos/WebProcess.cpp
+++ b/Source/WebKitLegacy/morphos/WebProcess.cpp
@@ -69,11 +69,21 @@ extern "C" {
 LONG WaitSelect(LONG nfds, fd_set *readfds, fd_set *writefds, fd_set *exeptfds,
                 struct timeval *timeout, ULONG *maskp);
 }
+#if !OS(AMIGAOS)
 typedef uint32_t socklen_t;
+#endif
 #if (!MORPHOS_MINIMAL) && !AMIGAOS_MINIMAL
 #include <pal/crypto/gcrypt/Initialization.h>
 #endif
+#if OS(MORPHOS)
 #include <proto/dos.h>
+#elif OS(AMIGAOS)
+#define DOS_DOSEXTENS_H
+#define __USE_INLINE__
+#include <proto/dos.h>
+#undef __USE_INLINE__
+#undef DOS_DOSEXTENS_H
+#endif
 
 #if (MORPHOS_MINIMAL) || AMIGAOS_MINIMAL
 #define USE_ADFILTER 0
@@ -81,9 +91,11 @@ typedef uint32_t socklen_t;
 #define USE_ADFILTER 1
 #endif
 
+#if !OS(AMIGAOS)
 extern "C" {
 	void dprintf(const char *, ...);
 };
+#endif
 
 #define D(x) 
 
@@ -229,9 +241,11 @@ void WebProcess::initialize(int sigbit)
 	RuntimeEnabledFeatures::sharedFeatures().setAccessibilityObjectModelEnabled(false);
 //	RuntimeEnabledFeatures::sharedFeatures().setKeygenElementEnabled(true);
 	
+#if ENABLE(OFFSCREEN_CANVAS)
     RuntimeEnabledFeatures::sharedFeatures().setOffscreenCanvasEnabled(true);
     RuntimeEnabledFeatures::sharedFeatures().setOffscreenCanvasInWorkersEnabled(true);
-    
+#endif
+
 // This doesn't work yet in WebKitLegacy so it will potentially break pages if enabled
     RuntimeEnabledFeatures::sharedFeatures().setCacheAPIEnabled(true);
     
@@ -744,7 +758,11 @@ void WebProcess::dumpWebCoreStatistics()
     // Get WebCore memory cache statistics
     getWebCoreMemoryCacheStatistics(ss);
 	
+	#if OS(AMIGAOS)
+	dprintf(0, ss.release().utf8().data());
+	#else
     dprintf(ss.release().utf8().data());
+	#endif
 }
 
 void reactOnMemoryPressureInWebKit()

--- a/Source/WebKitLegacy/morphos/WebProcess.cpp
+++ b/Source/WebKitLegacy/morphos/WebProcess.cpp
@@ -60,7 +60,7 @@
 #include <WebCore/PageConsoleClient.h>
 #include <WebCore/RuntimeEnabledFeatures.h>
 #include "Gamepad.h"
-#if !MORPHOS_MINIMAL && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 #include "WebDatabaseManager.h"
 #endif
 
@@ -72,7 +72,7 @@ LONG WaitSelect(LONG nfds, fd_set *readfds, fd_set *writefds, fd_set *exeptfds,
 #if !OS(AMIGAOS)
 typedef uint32_t socklen_t;
 #endif
-#if (!MORPHOS_MINIMAL) && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 #include <pal/crypto/gcrypt/Initialization.h>
 #endif
 #if OS(MORPHOS)
@@ -85,7 +85,7 @@ typedef uint32_t socklen_t;
 #undef DOS_DOSEXTENS_H
 #endif
 
-#if (MORPHOS_MINIMAL) || AMIGAOS_MINIMAL
+#if defined(MORPHOS_MINIMAL) || defined(AMIGAOS_MINIMAL)
 #define USE_ADFILTER 0
 #else
 #define USE_ADFILTER 1
@@ -215,7 +215,7 @@ void WebProcess::initialize(int sigbit)
 
 	GCController::singleton().setJavaScriptGarbageCollectorTimerEnabled(true);
 
-#if (!MORPHOS_MINIMAL) && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 	PAL::GCrypt::initialize();
 #endif
 
@@ -227,7 +227,7 @@ void WebProcess::initialize(int sigbit)
 #endif
 
 	WebPlatformStrategies::initialize();
-#if !MORPHOS_MINIMAL && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 	WebKitInitializeWebDatabasesIfNecessary();
 #endif
 
@@ -759,7 +759,7 @@ void WebProcess::dumpWebCoreStatistics()
     getWebCoreMemoryCacheStatistics(ss);
 	
 	#if OS(AMIGAOS)
-	dprintf(0, ss.release().utf8().data());
+	dprintf(1, ss.release().utf8().data());
 	#else
     dprintf(ss.release().utf8().data());
 	#endif

--- a/Source/WebKitLegacy/morphos/WebProcess.h
+++ b/Source/WebKitLegacy/morphos/WebProcess.h
@@ -11,7 +11,7 @@
 #include "NetworkSession.h"
 #include <wtf/HashCountedSet.h>
 
-#if !MORPHOS_MINIMAL && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
 #include "ABPFilterParser/ABPFilterParser.h"
 #endif
 
@@ -145,7 +145,7 @@ protected:
     CacheModel m_cacheModel { CacheModel::DocumentViewer };
     static const QUAD ms_diskCacheSizeUninitialized = 0x7FFFFFFFFFFFFFFFll;
     QUAD m_diskCacheSize { ms_diskCacheSizeUninitialized };
-#if !MORPHOS_MINIMAL && !AMIGAOS_MINIMAL
+#if !defined(MORPHOS_MINIMAL) && !defined(AMIGAOS_MINIMAL)
     ABP::ABPFilterParser m_urlFilter;
     std::vector<char>    m_urlFilterData;
 #endif

--- a/Source/WebKitLegacy/morphos/WebProcess.h
+++ b/Source/WebKitLegacy/morphos/WebProcess.h
@@ -15,6 +15,17 @@
 #include "ABPFilterParser/ABPFilterParser.h"
 #endif
 
+#if OS(AMIGAOS)
+#define __USE_INLINE__
+#include <proto/exec.h>
+#undef __USE_INLINE__
+
+#ifndef QUAD_TYPEDEF
+#define QUAD_TYPEDEF
+typedef signed long long   QUAD;
+#endif
+#endif
+
 namespace WebCore {
 	class DocumentLoader;
 	class CacheStorageProvider;
@@ -134,7 +145,7 @@ protected:
     CacheModel m_cacheModel { CacheModel::DocumentViewer };
     static const QUAD ms_diskCacheSizeUninitialized = 0x7FFFFFFFFFFFFFFFll;
     QUAD m_diskCacheSize { ms_diskCacheSizeUninitialized };
-#if (!MORPHOS_MINIMAL) && !AMIGAOS_MINIMAL
+#if !MORPHOS_MINIMAL && !AMIGAOS_MINIMAL
     ABP::ABPFilterParser m_urlFilter;
     std::vector<char>    m_urlFilterData;
 #endif

--- a/Source/WebKitLegacy/morphos/WebViewDelegate.h
+++ b/Source/WebKitLegacy/morphos/WebViewDelegate.h
@@ -8,8 +8,10 @@
 #include <WebCore/MediaPlayerMorphOS.h>
 #include <WebCore/NotificationClient.h>
 
+#if OS(MORPHOS)
 #define EP_PROFILING 0
 #include <libeventprofiler.h>
+#endif
 
 namespace WebCore {
 	class Page;


### PR DESCRIPTION
I did more fixes to continue the build of the minibrowser, where I:
- disabled the .mm files from being compiled
- fixed issues with methods being identified etc
- fixed issues with definitions
- included the fix from @kas1e that solved the previous problems
- removed some `#error` that were left back
- enabled the multithread compiling

This is a WIP. There is still a failure in the WebPage file, where the `WritePixelArray` fails on the rastport definition. That probably needs to change as a whole, since webkitty was written to use cybergraphics, but we need to use the graphics library and methods.